### PR TITLE
Makes `actions` accept a function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.sublime-*
+example/folder/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,51 @@ The `add` action is used to (you guessed it) add files to your project. The path
 #### Modify (Action)
 The `modify` action is similar to `add`, but the main difference is that it will use a `pattern` property to find/replace text in the file specified by the `path` property. The `pattern` property should be a RegExp and capture groups can be used in the replacement template using $1, $2, etc. More details on modify can be found in the example folder.
 
+### Using a function
+Alternatively, `actions` can be a function that takes responses `data` in parameter and should return an array of actions.
+
+This allows you to adapt actions to provided answers:
+
+``` javascript
+module.exports = function (plop) {
+    plop.setGenerator('test', {
+		description: 'this is a test',
+		prompts: [{
+			type: 'input',
+			name: 'name',
+			message: 'What is your name?',
+			validate: function (value) {
+				if ((/.+/).test(value)) { return true; }
+				return 'name is required';
+			}
+		},{
+			type: 'confirm',
+			name: 'wantTacos',
+			message: 'Do you want tacos?'
+		}],
+		actions: function(data) {
+			var actions = [];
+
+			if(data.wantTacos) {
+				actions.push({
+					type: 'add',
+					path: 'folder/{{dashCase name}}.txt',
+					templateFile: 'templates/tacos.txt'
+				});
+			} else {
+				actions.push({
+					type: 'add',
+					path: 'folder/{{dashCase name}}.txt',
+					templateFile: 'templates/burritos.txt'
+				});
+			}
+
+			return actions;
+		}
+	});
+};
+```
+
 ## Baked-In Helpers
 There are a few helpers that I have found useful enough to include with plop. They are mostly case modifiers, but here is the complete list.
 

--- a/example/plopfile.js
+++ b/example/plopfile.js
@@ -39,7 +39,7 @@ module.exports = function (plop) {
 			}, {
 				type: 'checkbox',
 				name: 'toppings',
-				message: 'What pizza toppings to you like?',
+				message: 'What pizza toppings do you like?',
 				choices: [
 					{name: 'Cheese', value: 'cheese', checked: true},
 					{name: 'Peperonni', value: 'peperonni'},

--- a/example/plopfile.js
+++ b/example/plopfile.js
@@ -73,4 +73,52 @@ module.exports = function (plop) {
 			}
 		]
 	});
+
+	// test with dynamic actions, regarding responses to prompts
+	plop.setGenerator('test with dynamic actions', {
+		description: 'this is another test',
+		prompts: [
+			{
+				type: 'input',
+				name: 'name',
+				message: 'What is your name?',
+				validate: function (value) {
+					if ((/.+/).test(value)) { return true; }
+					return 'name is required';
+				}
+			}, {
+				type: 'confirm',
+				name: 'hasPotatoes',
+				message: 'Do you want potatoes with your burger?'
+			}
+		],
+		actions: function(data) {
+			var actions = [
+				{
+					type: 'add',
+					path: 'folder/{{dashCase name}}-burger.txt',
+					templateFile: 'templates/burger.txt',
+					abortOnFail: true
+				}
+			];
+
+			if(data.hasPotatoes) {
+				actions = actions.concat([
+					{
+						type: 'add',
+						path: 'folder/{{dashCase name}}-potatoes.txt',
+						templateFile: 'templates/potatoes.txt',
+						abortOnFail: true
+					},{
+						type: 'modify',
+						path: 'folder/{{dashCase name}}-burger.txt',
+						pattern: /(!\n)/gi,
+						template: '$1Your potatoes: {{dashCase name}}-potatoes.txt'
+					}
+				]);
+			}
+
+			return actions;
+		}
+	});
 };

--- a/example/templates/burger.txt
+++ b/example/templates/burger.txt
@@ -1,0 +1,1 @@
+Here's your burger {{ properCase name }}!

--- a/example/templates/potatoes.txt
+++ b/example/templates/potatoes.txt
@@ -1,0 +1,1 @@
+Well {{ properCase name }}, it seems you asked for potatoes.

--- a/mod/logic.js
+++ b/mod/logic.js
@@ -44,6 +44,10 @@ module.exports = (function () {
 			actions = config.actions,
 			abort = false;
 
+		if(typeof actions === 'function') {
+			actions = actions(data);
+		}
+
 		actions.forEach(function (action, idx) {
 			chain = chain.then(function () {
 				var _d = q.defer(),


### PR DESCRIPTION
Hi there!

*First of all: thanks a lot for this handy tool. It's easy to setup, configure and use. It's super-flexible compared to the custom Yeoman generator we used before — no need to publish a new version and ensure everyone is up-to-date. That's awesome ;-)*

In our main project we quickly ran into a use case: when we create a new module it can have a collection+model or just a model, it may need a single item view or a collection view or a composite view…

The current way to do it would be either:

- to create one generator per scenario, which would quickly scale into a monster 
- to create a module, then to create a collection, then to create a model…

That would be nice if **plop** asks us if we want a model or a collection+model right during module creation, and produces everything needed as once. 

Hence, I simply made `actions` accept an array or a function that returns an array. If you provide a function, you've got prompts response in parameters. This way you can adapt actions regarding the answers.

This was the best solution I found to keep it simple. I've updated the README accordingly to explain this + made a usage example.

Passing by, this PR includes:

- ignoring `example/folder/` so it doesn't bother us in git when testing
- a little typo correction

Let me know if something is wrong or missing.
Cheers!