### PR TITLE
Add Help and Init

### DIFF
--- a/example/plopfile-bare.js
+++ b/example/plopfile-bare.js
@@ -1,0 +1,39 @@
+module.exports = function (plop) {
+	'use strict';
+
+	plop.addHelper('helper', function (text) {
+		return text;
+	});
+
+	plop.setGenerator('generator', {
+		description: 'simple generator',
+		prompts: [
+			{
+				// see here for possible options
+				// https://github.com/SBoudrias/Inquirer.js/#objects
+				type: 'input',
+				name: 'name',
+				message: 'What is your name?',
+				validate: function (value) {
+					if ((/.+/).test(value)) { return true; }
+					return 'name is required';
+				}
+			}
+		],
+		actions: [
+			// see here for more options
+			// https://github.com/amwmedia/plop#actions-array
+			{
+				type: 'add',
+				path: '', // path where file will be added
+				templateFile: 'plop-templates/file.txt' // path to the templateFile
+			},
+			{
+				type: 'modify',
+				path: '', // path to existing file to modify
+				pattern: /.+/gi, // use regex to pick location in file
+				template: '' // create a template here, or use a 'templateFile'
+			}
+		]
+	});
+};

--- a/example/plopfile.js
+++ b/example/plopfile.js
@@ -95,7 +95,7 @@ module.exports = function (plop) {
 	});
 
 	// test with dynamic actions, regarding responses to prompts
-	plop.setGenerator('test with dynamic actions', {
+	plop.setGenerator('dynamic', {
 		description: 'this is another test',
 		prompts: [
 			{

--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
   "dependencies": {
     "change-case": "^2.1.5",
     "colors": "^1.0.2",
+    "commander": "^2.9.0",
     "findup-sync": "^0.1.3",
     "handlebars": "^2.0.0",
+    "inquirer": "^0.10.0",
     "mkdirp": "^0.5.0",
     "prompt": "^0.2.14",
-    "inquirer": "^0.10.0",
     "q": "~1.0.1"
   },
   "preferGlobal": "true",


### PR DESCRIPTION
This pull request changes some of the core logic so that things run through [commander.js](https://github.com/tj/commander.js), and I'll admit that I was just plowing through to get a working version, so if other users could fetch this branch and test things, I'd feel a bit better about things. This fixes #2 

New features:
* adds a help menu when you run `plop` by itself, or if you run it in a directory where there is no `plopfile.js`, or if you run it with the `--help` or `-h` flags
* adds an `init` subcommand. `plop init` will generate a `plopfile.js` in the current directory and create a `plop-templates` directory.
* there are two versions of the `plopfile.js` that you can install using `plop init`:
  * the default installs a `plopfile.js` with just the basic boilerplate (the file used is in `/example/plopfile-bare.js`). I included some links in the comments of the minimal version, but I honestly haven't tested `plopfile-bare.js` much yet.
  * if you add the verbose flag, `plop init --verbose` or `plop init -v` it will install the `plopfile.js` found in `example/plopfile.js` that has all the bells and whistles.
* uses [commander.js](https://github.com/tj/commander.js) to handle all the option parsing and subcommand parsing
  * if you are in a directory that has a `plopfile.js`, commander parses the generators as subcommands too. So you can do things like `plop mygenerator --help` and see the help for the generator (which is just the description).

I'd like to add some tests to the repo too, so I might start work on that some time this weekend.