### PR TITLE
feat(directory-prompt): add directory type prompt plugin to inquirer

### DIFF
--- a/example/plopfile.js
+++ b/example/plopfile.js
@@ -47,6 +47,11 @@ module.exports = function (plop) {
 					{name: 'Mushroom', value: 'mushroom'},
 					{name: 'Bacon', value: 'bacon'}
 				]
+			}, {
+				type: 'directory',
+				name: 'templates',
+				message: 'Where is your templates folder?',
+				basePath: './'
 			}
 		],
 		actions: [

--- a/mod/logic.js
+++ b/mod/logic.js
@@ -9,6 +9,10 @@ module.exports = (function () {
 	var plop = require('./plop-base'),
 		fs = require('./fs-promise');
 
+	// register a `directory` type prompt that will allow users to ask
+	// where they would like a "plop" to go.
+	inquirer.registerPrompt('directory', require('inquirer-directory'));
+
 	var genName = '',
 		basePath = '',
 		abort = false,

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
     "colors": "^1.0.2",
     "findup-sync": "^0.1.3",
     "handlebars": "^2.0.0",
+    "inquirer": "^0.10.0",
+    "inquirer-directory": "^1.0.1",
     "mkdirp": "^0.5.0",
     "prompt": "^0.2.14",
-    "inquirer": "^0.10.0",
     "q": "~1.0.1"
   },
   "preferGlobal": "true",


### PR DESCRIPTION
When writing my generators, I found myself needing to ask the user, "where would like like to put this new component?" so I built a plugin for Inquirer that adds a new "directory" type prompt that allows users to select a directory relative to a given "basePath". I tried to get this new prompt type merged into the core of Inquirer, but the maintainer thought it would be better served as a plugin.

I think that this could be a common use-case for plop.js users (and plop doens't currently support any way of manually extending inquirer) so I am attempting to add my plugin here.

To read more about this plugin, you could visit [Inquirer-directory's github repo](https://github.com/nicksrandall/inquierer-directory).

If you like and decide to merge this in, I'd be happy to write some documention somewhere to let user know that is is available. 