### PR TITLE
allow template paths to be absolute (or relative)

### DIFF
--- a/mod/logic.js
+++ b/mod/logic.js
@@ -34,9 +34,9 @@ module.exports = (function () {
 		return _d.promise;
 	}
 
-	// make a full path from the basePath (plopfile location)
+	// if not already an absolute path, make an absolute path from the basePath (plopfile location)
 	function makePath(p) {
-		return path.join(basePath, p);
+		return path.isAbsolute(p) ? p : path.join(basePath, p);
 	}
 
 	// Run the actions for this generator


### PR DESCRIPTION
## Use case
I want to include my plopfile as a dependency that I can include in different projects. For example, if I was in an angular application, I could generate a plopflie.js that looks something like this:

```js
module.exports = require('angular-plop');
```

To accomplish that, I want my templates to be relative to `__dirname`, the actual location of plopflie logic, and not the plopfile itself. I should be able to set the templates as absolute path. With the change I made, if you set your path as an absolute path it will just use that path. If you set your path as a relative path, then it will automatically join that path to the plopfile's path. 

I hope that makes sense.