### PR TITLE
Help screen and an init plopfile via cli --options

### DIFF
--- a/plop.js
+++ b/plop.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var path = require('path');
+var fs = require('fs');
 var Liftoff = require('liftoff');
 var argv = require('minimist')(process.argv.slice(2));
 var v8flags = require('v8flags');
@@ -36,6 +37,18 @@ function run(env) {
 	if (argv.help || argv.h) {
 		displayHelpScreen();
 		process.exit(0);
+	}
+	
+	if (argv.init || argv.i) {
+		return createInitPlopfile(function(err){
+			if (err){
+				console.log(err);
+
+				process.exit(1);
+			}
+
+			process.exit(0);
+		});
 	}
 
 	// handle request for version number
@@ -83,6 +96,18 @@ function run(env) {
 		            '\t\t-h, --help\t\tShow this help display\n' +
 		            '\t\t-i, --init\t\tGenerate initial plopfile.js\n' +
 		            '\t\t-v, --version\t\tPrint current version\n');
+	}
+
+	function createInitPlopfile(callback){
+		var initString = 'module.exports = function (plop) {\n\n' +
+		                 '\tplop.setGenerator(\'basics\', {\n' +
+		                 '\t\tdescription: \'this is a skeleton plopfile\',\n' +
+		                 '\t\tprompts: [],\n' +
+		                 '\t\tactions: []\n' +
+		                 '\t});\n\n' +
+		                 '};';
+
+		fs.writeFile(env.cwd + '/plopfile.js', initString, callback);
 	}
 
 }

--- a/plop.js
+++ b/plop.js
@@ -32,6 +32,12 @@ Plop.launch({
 function run(env) {
 	var generators, plopfilePath;
 
+	// handle request for usage and options
+	if (argv.help || argv.h) {
+		displayHelpScreen();
+		process.exit(0);
+	}
+
 	// handle request for version number
 	if (argv.version || argv.v) {
 		if (env.modulePackage.version !== globalPkg.version) {
@@ -43,13 +49,15 @@ function run(env) {
 		return;
 	}
 
-	// set the default base path to the plopfile directory
 	plopfilePath = env.configPath;
 	// abort if there's no plopfile found
 	if (plopfilePath == null) {
 		console.error(colors.red('[PLOP] ') + 'No plopfile found');
+		displayHelpScreen();
 		process.exit(1);
 	}
+
+	// set the default base path to the plopfile directory
 	plop.setPlopfilePath(path.dirname(plopfilePath));
 
 	// run the plopfile against the plop object
@@ -64,6 +72,19 @@ function run(env) {
 		console.error(colors.red('[PLOP] ') + 'Generator "' + generator + '" not found in plopfile');
 		process.exit(1);
 	}
+
+	function displayHelpScreen(){
+		console.log('\n' +
+		            '\tUsage\n' +
+		            '\t\t$ plop <name>\t\tRun a generator registered under that name\n' +
+
+		            '\n' +
+		            '\tOptions\n' +
+		            '\t\t-h, --help\t\tShow this help display\n' +
+		            '\t\t-i, --init\t\tGenerate initial plopfile.js\n' +
+		            '\t\t-v, --version\t\tPrint current version\n');
+	}
+
 }
 
 function go(generator) {


### PR DESCRIPTION
This fixes #2 and tries to confort to the specs listed at https://github.com/amwmedia/plop/pull/3#issuecomment-162761445

I think there needs to be some more discussion regarding the init output, it could start a generator just like any plop generator would (or `npm -i`) and I do think that's the way to go since 1) So many options there and 2) Dog food.

As a start, I thought it'd fit to have a `plop -i` generate the simplest of plopfiles => the one that's shown on the [readme file](https://github.com/amwmedia/plop#3-create-a-plopfilejs-at-the-root-of-your-project)