### PR TITLE
Remove propt prefix with generator name

### DIFF
--- a/mod/logic.js
+++ b/mod/logic.js
@@ -21,12 +21,8 @@ module.exports = (function () {
 		config = plop.getGenerator(gName);
 
 		var _d = q.defer();
-		var prompts = config.prompts.map(function (p) {
-				p.message = colors.green('[' + gName.toUpperCase() + '] ') + p.message;
-				return p;
-			});
 
-		plop.inquirer.prompt(prompts, function (result) {
+		plop.inquirer.prompt(config.prompts, function (result) {
 			_d.resolve(result);
 		});
 


### PR DESCRIPTION
Hello,

I fell in love with plop as soon as I touched it! I love it how lightweight it feels to write a plopfile and to use `plop` from the CLI.

The only first impression that seems a bit less lightweight than the rest is the `[GENERATOR-NAME] ` prefix at the beginning of every prompt. In this PR I propose taking the prefixes out – but this is a subjective proposal, so feel free to close it if you like them. And again – it’s a first impression. Perhaps they are useful in scenarios that I don’t know as a newcomer.

Cheers for the great piece of code! :beers: