### PR TITLE
add support for inline generator arguments

### DIFF
--- a/mod/logic.js
+++ b/mod/logic.js
@@ -15,7 +15,7 @@ module.exports = (function () {
 
 	// triggers inquirer with the correct prompts for this generator
 	// returns a promise that resolves with the user's answers
-	function getPlopData(gName) {
+	function getPlopData(gName, gArgs) {
 		genName = gName;
 		basePath = plop.getPlopfilePath();
 		config = plop.getGenerator(gName);
@@ -26,9 +26,18 @@ module.exports = (function () {
 				return p;
 			});
 
-		plop.inquirer.prompt(prompts, function (result) {
-			_d.resolve(result);
-		});
+		if (!gArgs.length) {
+			plop.inquirer.prompt(prompts, function (result) {
+				_d.resolve(result);
+			});
+		} else { 
+			var result = {};
+			prompts.forEach((prompt, index) => {
+				result[prompt.name] = gArgs[index];
+
+				_d.resolve(result);
+			});
+		}
 
 		return _d.promise;
 	}

--- a/plop.js
+++ b/plop.js
@@ -14,6 +14,7 @@ var logic = require('./mod/logic');
 var out = require('./mod/console-out');
 var globalPkg = require('./package.json');
 var generator = argv._[0] || null;
+var generatorArgs = argv._.slice(1);
 
 var Plop = new Liftoff({
 	name: 'plop',
@@ -78,7 +79,7 @@ function run(env) {
 	if (!generator) {
 		out.chooseOptionFromList(generators).then(doThePlop);
 	}else if (generators.map(function (v) { return v.name; }).indexOf(generator) > -1) {
-		doThePlop(generator);
+		doThePlop(generator, generatorArgs);
 	} else {
 		console.error(colors.red('[PLOP] ') + 'Generator "' + generator + '" not found in plopfile');
 		process.exit(1);
@@ -86,8 +87,8 @@ function run(env) {
 
 }
 
-function doThePlop(generator) {
-	logic.getPlopData(generator)
+function doThePlop(generator, generatorArgs) {
+	logic.getPlopData(generator, generatorArgs)
 		.then(logic.executePlop)
 		.then(function (result) {
 			result.changes.forEach(function(line) {


### PR DESCRIPTION
This adds support for running generators without triggering prompts. For example:
`$ plop generatorname param1 param2`
