### PR TITLE
Enhance error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 example/folder/
 example/change-me.txt
 .idea
+.vscode

--- a/src/plop.js
+++ b/src/plop.js
@@ -91,8 +91,15 @@ function doThePlop(generator) {
 			result.changes.forEach(function(line) {
 				console.log(chalk.green('[SUCCESS]'), line.type, line.path);
 			});
-			result.failures.forEach(function(line) {
-				console.log(chalk.red('[FAILED]'), line.type, line.path, line.error);
+			result.failures.forEach(function (line) {
+				var logs = [chalk.red('[FAILED]')];
+				if (line.type) { logs.push(line.type) };
+				if (line.path) { logs.push(line.path) };
+				
+				var error = line.error || line.message;
+				logs.push(chalk.red(error));
+
+				console.log.apply(console, logs);
 			});
 		})
 		.catch(function (err) {


### PR DESCRIPTION
This should handle scenarios like #54.

Let's pretend a Handlebar helper is misspelled.

Before this PR:
<img width="1008" alt="before-enhanced-error-messages" src="https://cloud.githubusercontent.com/assets/1094774/22573697/7e04c90a-e9aa-11e6-88b0-74cbc3b4edb6.png">

After this PR:
<img width="1006" alt="after-enhanced-error-messages" src="https://cloud.githubusercontent.com/assets/1094774/22573700/7f865ad2-e9aa-11e6-95d6-3c3bb34c07a9.png">

It also put the error message in red to make the whole readable along the error type and path. The latter are only displayed if they exist.
I think it should cover broader failing scenario with better logs.

What do you think?