### PR TITLE
Document liftoff arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Micro-generator framework that makes it easy for an entire team to create files 
 
 ![plop demo](http://i.imgur.com/penUFkr.gif)
 
-Plop is essentially glue code between  [inquirer](https://github.com/SBoudrias/Inquirer.js/) prompts and [handlebar](https://github.com/wycats/handlebars.js/) templates. You can also add your own handlebar helper methods and use them in your templates.
+Plop is essentially glue code between [inquirer](https://github.com/SBoudrias/Inquirer.js/) prompts and [handlebar](https://github.com/wycats/handlebars.js/) templates. You can also add your own handlebar helper methods and use them in your templates.
 
 # Getting Started
 ## 1. Install plop globally
@@ -229,6 +229,8 @@ There are a few helpers that I have found useful enough to include with plop. Th
 
 # Usage
 Once plop is installed, and you have created a generator, you are ready to run plop from the terminal. Running `plop` with no parameters will present you with a list of generators to pick from. You can also run `plop [generatorName]` to trigger a generator directly.
+
+Run `plop --help` to display the manual of different options you can pass to plop, e.g., specify a custom path to the plopfile.
 
 ---
 

--- a/src/console-out.js
+++ b/src/console-out.js
@@ -35,7 +35,11 @@ module.exports = (function () {
 			'OPTIONS:\n' +
 			'  -h, --help\t\tShow this help display\n' +
 			'  -i, --init\t\tGenerate a basic plopfile.js\n' +
-			'  -v, --version\t\tPrint current version\n'
+			'  -v, --version\t\tPrint current version\n' +
+			'  --plopfile\t\tPath to the plopfile\n' +
+			'  --completion\t\tMethod to handle bash/zsh/whatever completions\n' +
+			'  --cwd\t\t\tDirectory from which relative paths are calculated against\n' +
+			'  --require\t\tString or array of modules to require before running plop\n'
 		);
 	}
 

--- a/src/plop.js
+++ b/src/plop.js
@@ -23,8 +23,7 @@ Plop.launch({
 	cwd: argv.cwd,
 	configPath: argv.plopfile,
 	require: argv.require,
-	completion: argv.completion,
-	verbose: argv.verbose
+	completion: argv.completion
 }, run);
 
 function run(env) {


### PR DESCRIPTION
I came across #37 and I found it was an easy one, so here it is:

<img width="715" alt="liftoff-arguments" src="https://cloud.githubusercontent.com/assets/1094774/22612686/8fe0c2dc-ea72-11e6-83c0-3b007d6ac39d.png">

I didn't put these info in the README. Instead I indicated how to display plop options with `plop --help`. That way information is not duplicated, which I feel less risky to get out of sync in the future.

Also, I dropped the `verbose` argument which didn't seem to do anything. I couldn't find it in the [liftoff doc](https://github.com/js-cli/js-liftoff#launchopts-callbackenv) neither.

Does that seems good to you?