### PR TITLE
Customize the starting prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ loads generators, helpers and/or partials from another plopfile or npm module
 
 Renders the handlebars `template` using the `data` passed in. Returns the rendered template.
 
+### plop.setStartingPrompt(message)
+ - message {String}
+
+Customizes the displayed message that asks you to choose a generator when you run `plop`.
+
 #### plop.getGenerator(name)
  - name {String}
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ loads generators, helpers and/or partials from another plopfile or npm module
 
 Renders the handlebars `template` using the `data` passed in. Returns the rendered template.
 
-### plop.setStartingPrompt(message)
+### plop.setWelcomeMessage(message)
  - message {String}
 
 Customizes the displayed message that asks you to choose a generator when you run `plop`.

--- a/example/plopfile.js
+++ b/example/plopfile.js
@@ -2,6 +2,9 @@
 const path = require('path');
 
 module.exports = function (plop) {
+	// starting prompt can be customize to display what you want
+	// plop.setStartingPrompt('[CUSTOM]'.yellow + ' What can I do for you?');
+
 	// helpers are passed through to handlebars and made
 	// available for use in the generator templates
 

--- a/example/plopfile.js
+++ b/example/plopfile.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 module.exports = function (plop) {
 	// starting prompt can be customize to display what you want
-	// plop.setStartingPrompt('[CUSTOM]'.yellow + ' What can I do for you?');
+	// plop.setWelcomeMessage('[CUSTOM]'.yellow + ' What can I do for you?');
 
 	// helpers are passed through to handlebars and made
 	// available for use in the generator templates

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "interpret": "^1.0.0",
     "liftoff": "^2.2.0",
     "minimist": "^1.2.0",
-    "node-plop": "=0.7.1",
+    "node-plop": "=0.8.0",
     "v8flags": "^2.0.10"
   },
   "engines": {
-    "node": ">=4.0"
+    "node": ">=4.8.4"
   },
   "preferGlobal": "true",
   "bin": {

--- a/src/console-out.js
+++ b/src/console-out.js
@@ -4,15 +4,17 @@ var chalk = require('chalk');
 var nodePlop = require('node-plop');
 var fs = require('fs');
 
+var defaultChoosingMessage = '[PLOP]'.blue + ' Please choose a generator.';
+
 module.exports = (function () {
 
-	function chooseOptionFromList(plopList) {
+	function chooseOptionFromList(plopList, message = defaultChoosingMessage) {
 		const plop = nodePlop();
 		const generator = plop.setGenerator('choose', {
 			prompts: [{
 				type: 'list',
 				name: 'generator',
-				message: '[PLOP]'.blue + ' Please choose a generator.',
+				message,
 				choices: plopList.map(function (p) {
 					return {
 						name: p.name + chalk.gray(!!p.description ? ' - ' + p.description : ''),

--- a/src/plop.js
+++ b/src/plop.js
@@ -80,9 +80,10 @@ function run(env) {
 				break;
 
 			default:
-				out.chooseOptionFromList(generators).then(function (generatorName) {
-					doThePlop(plop.getGenerator(generatorName));
-				});
+				out.chooseOptionFromList(generators, plop.getStartingPrompt())
+					.then(function (generatorName) {
+						doThePlop(plop.getGenerator(generatorName));
+					});
 				break;
 		}
 	} else if (generators.map(function (v) { return v.name; }).indexOf(generator) > -1) {

--- a/src/plop.js
+++ b/src/plop.js
@@ -80,7 +80,7 @@ function run(env) {
 				break;
 
 			default:
-				out.chooseOptionFromList(generators, plop.getStartingPrompt())
+				out.chooseOptionFromList(generators, plop.getWelcomeMessage())
 					.then(function (generatorName) {
 						doThePlop(plop.getGenerator(generatorName));
 					});


### PR DESCRIPTION
Closes #39.

This requires https://github.com/amwmedia/node-plop/pull/39 first.

Calling `plop.setWelcomeMessage('[CUSTOM]'.yellow + ' What can I do for you?');` will display:

<img width="500" alt="capture d ecran 2017-08-28 a 07 46 41" src="https://user-images.githubusercontent.com/1094774/29762324-447618e4-8bce-11e7-9a19-c2ee3c1b7ee8.png">

If you don't set a message, it will fallback on the default one − which is the current one. 