### PR TITLE
Add a cli option for choosing de base destination folder

### DIFF
--- a/src/console-out.js
+++ b/src/console-out.js
@@ -39,6 +39,7 @@ module.exports = (function () {
 			'  --plopfile\t\tPath to the plopfile\n' +
 			'  --completion\t\tMethod to handle bash/zsh/whatever completions\n' +
 			'  --cwd\t\t\tDirectory from which relative paths are calculated against\n' +
+			'  --destBasePath\tDirectory to take as base when calculating the destination of files\n' +
 			'  --require\t\tString or array of modules to require before running plop\n'
 		);
 	}

--- a/src/plop.js
+++ b/src/plop.js
@@ -65,8 +65,13 @@ function run(env) {
 		process.exit(1);
 	}
 
-	// set the default base path to the plopfile directory
-	plop = nodePlop(plopfilePath);
+	// set options
+	var options = {}
+	if (argv.destBasePath) {
+		options.destBasePath = argv.destBasePath
+	}
+	// initiate nodePlop
+	plop = nodePlop(plopfilePath, options);
 	generators = plop.getGeneratorList();
 	if (!generator) {
 		switch (generators.length) {


### PR DESCRIPTION
With this option, users will be able to choose where to put the generated code.
This option is useful for when you place your plopfile.js other than your root folder, such as being when placed inside a nested folder in a monorepo structure.