### PR TITLE
Make Node 4 compatible

### DIFF
--- a/src/console-out.js
+++ b/src/console-out.js
@@ -8,13 +8,13 @@ const defaultChoosingMessage = chalk.blue('[PLOP]') + ' Please choose a generato
 
 module.exports = (function () {
 
-	function chooseOptionFromList(plopList, message = defaultChoosingMessage) {
+	function chooseOptionFromList(plopList, message) {
 		const plop = nodePlop();
 		const generator = plop.setGenerator('choose', {
 			prompts: [{
 				type: 'list',
 				name: 'generator',
-				message,
+				message: message || defaultChoosingMessage,
 				choices: plopList.map(function (p) {
 					return {
 						name: p.name + chalk.gray(!!p.description ? ' - ' + p.description : ''),


### PR DESCRIPTION
Commit d07972ba0f6ce87545a87f84ba4224425b55254e in #87 added a default parameter which isn't supported in Node 4. As a result the `plop` library was no longer able to run in Node 4.

Making the lib Node 4 compatible again by replacing the default parameter with an ES5 equivalent. I verified this works, but installing in Node 4 and running `node src/plop.js`

Fixes #99