### PR TITLE
Added feature: Named argument bypass

### DIFF
--- a/src/console-out.js
+++ b/src/console-out.js
@@ -8,6 +8,19 @@ const defaultChoosingMessage = chalk.blue('[PLOP]') + ' Please choose a generato
 
 module.exports = (function () {
 
+	function getHelpMessage(generator) {
+		const maxLen = Math.max(...generator.prompts.map(prompt => prompt.name.length));
+		console.log([
+			'',
+			chalk.bold('Options:'),
+			...generator.prompts.map(prompt =>
+				'  --' + prompt.name +
+				' '.repeat(maxLen - prompt.name.length + 2) +
+				chalk.dim(prompt.help ? prompt.help : prompt.message)
+			)
+		].join('\n'));
+	}
+
 	function chooseOptionFromList(plopList, message) {
 		const plop = nodePlop();
 		const generator = plop.setGenerator('choose', {
@@ -67,6 +80,7 @@ module.exports = (function () {
 	return {
 		chooseOptionFromList: chooseOptionFromList,
 		displayHelpScreen: displayHelpScreen,
-		createInitPlopfile: createInitPlopfile
+		createInitPlopfile: createInitPlopfile,
+		getHelpMessage: getHelpMessage
 	};
 })();

--- a/src/plop.js
+++ b/src/plop.js
@@ -141,6 +141,7 @@ function run(env) {
 	// Check if bypassArr is too long for promptNames
 	if (bypassArr.length > promptNames.length) {
 		console.error(chalk.red('[PLOP] ') + 'Too many bypass arguments passed for "' + generator.name + '"');
+		out.getHelpMessage(generator);
 		process.exit(1);
 	}
 
@@ -154,9 +155,9 @@ function run(env) {
 			}
 		});
 		if (errors) {
+			out.getHelpMessage(generator);
 			process.exit(1);
 		}
-		console.log(plopArgV);
 		const namedBypassArr = promptNames.map(name => plopArgV[name] ? plopArgV[name] : undefined);
 		const bypass = mergeArrays(bypassArr, namedBypassArr);
 		doThePlop(generator, bypass);

--- a/src/plop.js
+++ b/src/plop.js
@@ -4,7 +4,7 @@
 
 const Liftoff = require('liftoff');
 const args = process.argv.slice(2);
-const minimist = require('minimist')
+const minimist = require('minimist');
 const argv = minimist(args);
 const v8flags = require('v8flags');
 const interpret = require('interpret');
@@ -15,201 +15,206 @@ const out = require('./console-out');
 const globalPkg = require('../package.json');
 
 const Plop = new Liftoff({
-	name: 'plop',
-	extensions: interpret.jsVariants,
-	v8flags: v8flags
+  name: 'plop',
+  extensions: interpret.jsVariants,
+  v8flags: v8flags
 });
 
 Plop.launch({
-	cwd: argv.cwd,
-	configPath: argv.plopfile,
-	require: argv.require,
-	completion: argv.completion
+  cwd: argv.cwd,
+  configPath: argv.plopfile,
+  require: argv.require,
+  completion: argv.completion
 }, run);
 
 function run(env) {
-	// Make sure that we're not overwritting `help`, `init,` or `version` args in generators
-	if (argv._.length === 0) {
-		// handle request for usage and options
-		if (argv.help || argv.h) {
-			out.displayHelpScreen();
-			process.exit(0);
-		}
+  // Make sure that we're not overwritting `help`, `init,` or `version` args in generators
+  if (argv._.length === 0) {
+    // handle request for usage and options
+    if (argv.help || argv.h) {
+      out.displayHelpScreen();
+      process.exit(0);
+    }
 
-		// handle request for initializing a new plopfile
-		if (argv.init || argv.i) {
-			return out.createInitPlopfile(env.cwd, function (err) {
-				if (err) {
-					console.log(err);
-					process.exit(1);
-				}
-				process.exit(0);
-			});
-		}
+    // handle request for initializing a new plopfile
+    if (argv.init || argv.i) {
+      return out.createInitPlopfile(env.cwd, function (err) {
+        if (err) {
+          console.log(err);
+          process.exit(1);
+        }
+        process.exit(0);
+      });
+    }
 
-		// handle request for version number
-		if (argv.version || argv.v) {
-			if (env.modulePackage.version !== globalPkg.version) {
-				console.log(chalk.yellow('CLI version'), globalPkg.version);
-				console.log(chalk.yellow('Local version'), env.modulePackage.version);
-			} else {
-				console.log(globalPkg.version);
-			}
-			return;
-		}
-	}
+    // handle request for version number
+    if (argv.version || argv.v) {
+      if (env.modulePackage.version !== globalPkg.version) {
+        console.log(chalk.yellow('CLI version'), globalPkg.version);
+        console.log(chalk.yellow('Local version'), env.modulePackage.version);
+      } else {
+        console.log(globalPkg.version);
+      }
+      return;
+    }
+  }
 
-	// See if there are args to pass to generator
-	let plopArgV = [];
-	// End of Args
-	let eoaArg;
-	const eoaIndex = args.indexOf('--');
-	if (eoaIndex !== -1) {
-		plopArgV = minimist(args.slice(eoaIndex + 1, args.length));
-		eoaArg = args[eoaIndex + 1];
-	}
+  // See if there are args to pass to generator
+  const eoaIndex = args.indexOf('--');
+  const {plopArgV, eoaArg} = eoaIndex === -1 ? {plopArgV: []} : {
+    plopArgV: minimist(args.slice(eoaIndex + 1, args.length)),
+    eoaArg: args[eoaIndex + 1]
+  };
 
-	const plopfilePath = env.configPath;
+  const plopfilePath = env.configPath;
 
-	// abort if there's no plopfile found
-	if (plopfilePath == null) {
-		console.error(chalk.red('[PLOP] ') + 'No plopfile found');
-		out.displayHelpScreen();
-		process.exit(1);
-	}
+  // abort if there's no plopfile found
+  if (plopfilePath == null) {
+    console.error(chalk.red('[PLOP] ') + 'No plopfile found');
+    out.displayHelpScreen();
+    process.exit(1);
+  }
 
-	// set the default base path to the plopfile directory
-	const plop = nodePlop(plopfilePath, {
-		force: argv.force || argv.f
-	});
-	const generators = plop.getGeneratorList();
+  // set the default base path to the plopfile directory
+  const plop = nodePlop(plopfilePath, {
+    force: argv.force || argv.f
+  });
+  const generators = plop.getGeneratorList();
 
-	const generatorNames = generators.map(function (v) {
-		return v.name;
-	});
+  const generatorNames = generators.map((v) => v.name);
 
-	// locate the generator name based on input and take the rest of the
-	// user's input as prompt bypass data to be passed into the generator
-	let generatorName = '';
-	let bypassArr = [];
+  // locate the generator name based on input and take the rest of the
+  // user's input as prompt bypass data to be passed into the generator
+  let generatorName = '';
+  let bypassArr = [];
 
-	for (let i = 0; i < argv._.length; i++) {
-		const nameTest = (generatorName.length ? generatorName + ' ' : '') + argv._[i];
-		if (listHasOptionThatStartsWith(generatorNames, nameTest)) {
-			generatorName = nameTest;
-		} else {
-			let index = argv._.findIndex(arg => arg === eoaArg);
-			// If can't find index, slice until the very end - allowing all `_` to be passed
-			index = index !== -1 ? index : argv._.length;
-			// Force `'_'` to become undefined in nameless bypassArr
-			bypassArr = argv._.slice(i, index).map(arg => arg === '_' ? undefined : arg);
-			break;
-		}
-	}
+  for (let i = 0; i < argv._.length; i++) {
+    const nameTest = (generatorName.length ? generatorName + ' ' : '') + argv._[i];
+    if (listHasOptionThatStartsWith(generatorNames, nameTest)) {
+      generatorName = nameTest;
+    } else {
+      let index = argv._.findIndex(arg => arg === eoaArg);
+      // If can't find index, slice until the very end - allowing all `_` to be passed
+      index = index !== -1 ? index : argv._.length;
+      // Force `'_'` to become undefined in nameless bypassArr
+      bypassArr = argv._.slice(i, index).map(arg => arg === '_' ? undefined : arg);
+      break;
+    }
+  }
 
-	// Find generator to be ran
-	let generator;
-
-	// hmmmm, couldn't identify a generator in the user's input
-	if (!generatorName && !generators.length) {
-		// no generators?! there's clearly something wrong here
-		console.error(chalk.red('[PLOP] ') + 'No generator found in plopfile');
-		process.exit(1);
-	} else if (!generatorName && generators.length === 1) {
-		// only one generator in this plopfile... let's assume they
-		// want to run that one!
-		generator = plop.getGenerator(generatorNames[0]);
-	} else if (!generatorName && generators.length > 1 && !bypassArr.length) {
-		// more than one generator? we'll have to ask the user which
-		// one they want to run.
-		out.chooseOptionFromList(generators, plop.getWelcomeMessage()).then((generatorName) => {
-			generator = plop.getGenerator(generatorName);
-		});
-	} else if (generatorNames.indexOf(generatorName) >= 0) {
-		// we have found the generator, run it!
-		generator = plop.getGenerator(generatorName);
-	} else {
-		// we just can't make sense of your input... sorry :-(
-		const fuzyGenName = (generatorName + ' ' + bypassArr.join(' ')).trim();
-		console.error(chalk.red('[PLOP] ') + 'Could not find a generator for "' + fuzyGenName + '"');
-		process.exit(1);
-	}
-
-	// Get named prompts that are passed to the command line
-	const promptNames = generator.prompts.map(prompt => prompt.name);
-
-	// Check if bypassArr is too long for promptNames
-	if (bypassArr.length > promptNames.length) {
-		console.error(chalk.red('[PLOP] ') + 'Too many bypass arguments passed for "' + generator.name + '"');
-		out.getHelpMessage(generator);
-		process.exit(1);
-	}
-
-	if (Object.keys(plopArgV).length > 0) {
-		// Let's make sure we made no whoopsy-poos (AKA passing incorrect inputs)
-		let errors = false;
-		Object.keys(plopArgV).forEach(arg => {
-			if (!(promptNames.find(name => name === arg)) && arg !== '_') {
-				console.error(chalk.red('[PLOP] ') + '"' + arg + '"' + ' is an invalid argument for "' + generator.name + '"');
-				errors = true;
-			}
-		});
-		if (errors) {
-			out.getHelpMessage(generator);
-			process.exit(1);
-		}
-		const namedBypassArr = promptNames.map(name => plopArgV[name] ? plopArgV[name] : undefined);
-		const bypass = mergeArrays(bypassArr, namedBypassArr);
-		doThePlop(generator, bypass);
-	} else {
-		doThePlop(generator, bypassArr);
-	}
-
+  // hmmmm, couldn't identify a generator in the user's input
+  if (!generatorName && !generators.length) {
+    // no generators?! there's clearly something wrong here
+    console.error(chalk.red('[PLOP] ') + 'No generator found in plopfile');
+    process.exit(1);
+  } else if (!generatorName && generators.length === 1) {
+    // only one generator in this plopfile... let's assume they
+    // want to run that one!
+    handlePromptBypass(plop.getGenerator(generatorNames[0]), bypassArr, plopArgV);
+  } else if (!generatorName && generators.length > 1 && !bypassArr.length) {
+    // more than one generator? we'll have to ask the user which
+    // one they want to run.
+    out.chooseOptionFromList(generators, plop.getWelcomeMessage())
+      .then((generatorName) => {
+        handlePromptBypass(plop.getGenerator(generatorName), bypassArr, plopArgV);
+      })
+      .catch((err) => {
+        console.error(chalk.red('[PLOP] ') + 'Something went wrong with selecting a generator', err);
+      });
+  } else if (generatorNames.includes(generatorName)) {
+    // we have found the generator, run it!
+    handlePromptBypass(plop.getGenerator(generatorName), bypassArr, plopArgV);
+  } else {
+    // we just can't make sense of your input... sorry :-(
+    const fuzyGenName = (generatorName + ' ' + bypassArr.join(' ')).trim();
+    console.error(chalk.red('[PLOP] ') + 'Could not find a generator for "' + fuzyGenName + '"');
+    process.exit(1);
+  }
 }
+
+/**
+ *
+ * @param generator - Name of the generator to be ran
+ * @param bypassArr - The array of overwritten properties
+ * @param plopArgV - The original args passed to plop without using names
+ */
+function handlePromptBypass(generator, bypassArr, plopArgV) {
+
+  // Get named prompts that are passed to the command line
+  const promptNames = generator.prompts.map((prompt) => prompt.name);
+
+  // Check if bypassArr is too long for promptNames
+  if (bypassArr.length > promptNames.length) {
+    console.error(chalk.red('[PLOP] ') + 'Too many bypass arguments passed for "' + generator.name + '"');
+    out.getHelpMessage(generator);
+    process.exit(1);
+  }
+
+  if (Object.keys(plopArgV).length > 0) {
+    // Let's make sure we made no whoopsy-poos (AKA passing incorrect inputs)
+    let errors = false;
+    Object.keys(plopArgV).forEach((arg) => {
+      if (!(promptNames.find((name) => name === arg)) && arg !== '_') {
+        console.error(chalk.red('[PLOP] ') + '"' + arg + '"' + ' is an invalid argument for "' + generator.name + '"');
+        errors = true;
+      }
+    });
+    if (errors) {
+      out.getHelpMessage(generator);
+      process.exit(1);
+    }
+    const namedBypassArr = promptNames.map((name) => plopArgV[name] ? plopArgV[name] : undefined);
+    const bypass = mergeArrays(bypassArr, namedBypassArr);
+    doThePlop(generator, bypass);
+  } else {
+    doThePlop(generator, bypassArr);
+  }
+}
+
 
 /////
 // everybody to the plop!
 //
 function doThePlop(generator, bypassArr) {
-	generator.runPrompts(bypassArr)
-		.then(generator.runActions)
-		.then(function (result) {
-			result.changes.forEach(function (line) {
-				console.log(chalk.green('[SUCCESS]'), line.type, line.path);
-			});
-			result.failures.forEach(function (line) {
-				const logs = [chalk.red('[FAILED]')];
-				if (line.type) {
-					logs.push(line.type);
-				}
-				if (line.path) {
-					logs.push(line.path);
-				}
+  generator.runPrompts(bypassArr)
+    .then(generator.runActions)
+    .then(function (result) {
+      result.changes.forEach(function (line) {
+        console.log(chalk.green('[SUCCESS]'), line.type, line.path);
+      });
+      result.failures.forEach(function (line) {
+        const logs = [chalk.red('[FAILED]')];
+        if (line.type) {
+          logs.push(line.type);
+        }
+        if (line.path) {
+          logs.push(line.path);
+        }
 
-				const error = line.error || line.message;
-				logs.push(chalk.red(error));
+        const error = line.error || line.message;
+        logs.push(chalk.red(error));
 
-				console.log.apply(console, logs);
-			});
-		})
-		.catch(function (err) {
-			console.error(chalk.red('[ERROR]'), err.message);
-			process.exit(1);
-		});
+        console.log.apply(console, logs);
+      });
+    })
+    .catch(function (err) {
+      console.error(chalk.red('[ERROR]'), err.message);
+      process.exit(1);
+    });
 }
 
 function listHasOptionThatStartsWith(list, prefix) {
-	return list.some(function (txt) {
-		return txt.indexOf(prefix) === 0;
-	});
+  return list.some(function (txt) {
+    return txt.indexOf(prefix) === 0;
+  });
 }
 
 function mergeArrays(oldArr, newArr) {
-	const length = oldArr.length > newArr.length ? oldArr.length : newArr.length;
-	const returnArr = [];
-	for (let i = 0; i < length; i++) {
-		returnArr.push(!(newArr[i] === undefined || newArr[i] === '_') ? newArr[i] :
-			oldArr[i] === undefined ? '_' : oldArr[i]);
-	}
-	return returnArr;
+  const length = oldArr.length > newArr.length ? oldArr.length : newArr.length;
+  const returnArr = [];
+  for (let i = 0; i < length; i++) {
+    returnArr.push(!(newArr[i] === undefined || newArr[i] === '_') ? newArr[i] :
+      oldArr[i] === undefined ? '_' : oldArr[i]);
+  }
+  return returnArr;
 }


### PR DESCRIPTION
This feature implements #109 by adding named bypass args by using `plop generator args -- --named args` style. Additionally, if args are bypassed in the wrong way (too many args or incorrectly named args), it will throw a help page listing all arguments. 

Things from #109 that were not added:
- Typings for generator options menu. I was unsure how you wanted to implement that, so I left it out for the initial commit
- Allowing `'_'` in named args passing values. This was done so that there wouldn't have to be breaking releases in `node-plop` for the initial feature set. If requested, I can create a seperate PR for that functionality